### PR TITLE
Removendo container phpmyadmin do docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -152,24 +152,6 @@ services:
         - backend
       restart: unless-stopped
 
-### phpMyAdmin Container ####################################
-
-    phpmyadmin:
-      build: ./laradock/phpmyadmin
-      environment:
-        - PMA_ARBITRARY=1
-        - MYSQL_USER=${PMA_USER}
-        - MYSQL_PASSWORD=${PMA_PASSWORD}
-        - MYSQL_ROOT_PASSWORD=${PMA_ROOT_PASSWORD}
-      ports:
-        - "${PMA_PORT}:80"
-      depends_on:
-        - "${PMA_DB_ENGINE}"
-      networks:
-        - frontend
-        - backend
-      restart: unless-stopped
-
 
 ### Networks Setup ############################################
 


### PR DESCRIPTION
Alteração da engine de banco de dados de MySQL para PostgreSQL, para tentarmos subir dois ambientes (dev e master) sem comprometer a instância t2.micro, que possui apenas 1 GB de memória RAM.