### PR TITLE
Removendo helper `url()` do form de Registro

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -5,27 +5,27 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>3D Financial Academy</title>
 
-    <!-- Tell the browser to be responsive to screen width -->
+    // Tell the browser to be responsive to screen width
     <meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" name="viewport">
 
-    <!-- Bootstrap 3.3.7 -->
+    // Bootstrap 3.3.7
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
 
-    <!-- Font Awesome -->
+    // Font Awesome
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 
-    <!-- Ionicons -->
+    // Ionicons
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/ionicons/2.0.1/css/ionicons.min.css">
 
-    <!-- Theme style -->
+    // Theme style
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/admin-lte/2.4.2/css/AdminLTE.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/admin-lte/2.4.2/css/skins/_all-skins.min.css">
 
-    <!-- iCheck -->
+    // iCheck
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/iCheck/1.0.2/skins/square/_all.css">
 
-    <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
-    <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
+    // HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries
+    // WARNING: Respond.js doesn't work if you view the page via file://
     <!--[if lt IE 9]>
     <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
     <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
@@ -35,14 +35,14 @@
 <body class="hold-transition login-page">
 <div class="login-box">
     <div class="login-logo">
-        <a href="{{ url('/home') }}"><b>3D </b>Financial Academy</a>
+        <a href="/home"><b>3D </b>Financial Academy</a>
     </div>
 
-    <!-- /.login-logo -->
+    // .login-logo
     <div class="login-box-body">
         <p class="login-box-msg">Faça login para iniciar sua sessão</p>
 
-        <form method="post" action="{{ url('/login') }}">
+        <form method="post" action="/login">
             {!! csrf_field() !!}
 
             <div class="form-group has-feedback {{ $errors->has('email') ? ' has-error' : '' }}">
@@ -73,11 +73,9 @@
                         </label>
                     </div>
                 </div>
-                <!-- /.col -->
                 <div class="col-xs-4">
                     <button type="submit" class="btn btn-primary btn-block btn-flat">Login</button>
                 </div>
-                <!-- /.col -->
             </div>
         </form>
 
@@ -85,14 +83,12 @@
         <a href="{{ url('/register') }}" class="text-center">Cadastro</a>
 
     </div>
-    <!-- /.login-box-body -->
 </div>
-<!-- /.login-box -->
 
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
 
-<!-- AdminLTE App -->
+// AdminLTE App
 <script src="https://cdnjs.cloudflare.com/ajax/libs/admin-lte/2.4.2/js/adminlte.min.js"></script>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/iCheck/1.0.2/icheck.min.js"></script>

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -5,27 +5,27 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>InfyOm Laravel Generator | Registration Page</title>
 
-    <!-- Tell the browser to be responsive to screen width -->
+    // Tell the browser to be responsive to screen width
     <meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" name="viewport">
 
-    <!-- Bootstrap 3.3.7 -->
+    // Bootstrap 3.3.7
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
 
-    <!-- Font Awesome -->
+    // Font Awesome
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 
-    <!-- Ionicons -->
+    // Ionicons
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/ionicons/2.0.1/css/ionicons.min.css">
 
-    <!-- Theme style -->
+    // Theme style
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/admin-lte/2.4.2/css/AdminLTE.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/admin-lte/2.4.2/css/skins/_all-skins.min.css">
 
-    <!-- iCheck -->
+    // iCheck
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/iCheck/1.0.2/skins/square/_all.css">
 
-    <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
-    <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
+    // HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries
+    // WARNING: Respond.js doesn't work if you view the page via file://
     <!--[if lt IE 9]>
     <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
     <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
@@ -96,24 +96,24 @@
                         </label>
                     </div>
                 </div>
-                <!-- /.col -->
+                // /.col
                 <div class="col-xs-4">
                     <button type="submit" class="btn btn-primary btn-block btn-flat">Register</button>
                 </div>
-                <!-- /.col -->
+                // /.col
             </div>
         </form>
 
         <a href="{{ url('/login') }}" class="text-center">I already have a membership</a>
     </div>
-    <!-- /.form-box -->
+    // /.form-box
 </div>
-<!-- /.register-box -->
+// /.register-box
 
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
 
-<!-- AdminLTE App -->
+// AdminLTE App
 <script src="https://cdnjs.cloudflare.com/ajax/libs/admin-lte/2.4.2/js/adminlte.min.js"></script>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/iCheck/1.0.2/icheck.min.js"></script>


### PR DESCRIPTION
Assim como fiz em outras páginas, como a de login, precisei fazer o
mesmo para o form register, pois ao cadastrar novo usuário, não salvava
o usuário e também não dava erro (o que achei estranho).

Ao invés de investigar o problema, preferi já abrir a aba Security no
Developer Tools do Chrome e ver o que tinha de informações lá. Novamente
havia um insecure form, então pensei em corrigir e padronizar com os
demais formulários.

Também aproveitei o commit para padronizar alguns comentários em blade,
ao invés de usar o padrão `<!-- -->` do HTML, utilizamos o `//` como
comentário, que funciona bem no syntax highlighting do VS Code.