### PR TITLE
Feature/160158850 | Endpoints para respostas do cubo/anexos

### DIFF
--- a/app/Http/Controllers/TextoEntradaController.php
+++ b/app/Http/Controllers/TextoEntradaController.php
@@ -20,7 +20,6 @@ class TextoEntradaController extends AppBaseController
     public function __construct(TextoEntradaRepository $textoEntradaRepo)
     {
         $this->textoEntradaRepository = $textoEntradaRepo;
-        $this->middleware('auth');
     }
 
     /**

--- a/app/Http/Controllers/TextoEntradaController.php
+++ b/app/Http/Controllers/TextoEntradaController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\DataTables\TextoEntradaDataTable;
+use App\Models\TextoEntrada;
 use App\Http\Requests;
 use App\Http\Requests\CreateTextoEntradaRequest;
 use App\Http\Requests\UpdateTextoEntradaRequest;
@@ -19,6 +20,7 @@ class TextoEntradaController extends AppBaseController
     public function __construct(TextoEntradaRepository $textoEntradaRepo)
     {
         $this->textoEntradaRepository = $textoEntradaRepo;
+        $this->middleware('auth');
     }
 
     /**
@@ -30,6 +32,16 @@ class TextoEntradaController extends AppBaseController
     public function index(TextoEntradaDataTable $textoEntradaDataTable)
     {
         return $textoEntradaDataTable->render('texto_entradas.index');
+    }
+
+    /**
+     * Retorna Listagem de Textos de Entrada
+     *
+     * @return Response
+     */
+    public function textoEntrada()
+    {
+    	return response(TextoEntrada::get());
     }
 
     /**

--- a/app/Http/Controllers/TextoExposicaoACriseController.php
+++ b/app/Http/Controllers/TextoExposicaoACriseController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\TextoExposicaoACrise;
 use App\DataTables\TextoExposicaoACriseDataTable;
 use App\Http\Requests;
 use App\Http\Requests\CreateTextoExposicaoACriseRequest;
@@ -19,6 +20,7 @@ class TextoExposicaoACriseController extends AppBaseController
     public function __construct(TextoExposicaoACriseRepository $textoExposicaoACriseRepo)
     {
         $this->textoExposicaoACriseRepository = $textoExposicaoACriseRepo;
+        $this->middleware('auth');
     }
 
     /**
@@ -30,6 +32,16 @@ class TextoExposicaoACriseController extends AppBaseController
     public function index(TextoExposicaoACriseDataTable $textoExposicaoACriseDataTable)
     {
         return $textoExposicaoACriseDataTable->render('texto_exposicao_a_crises.index');
+    }
+
+    /**
+     * Retorna Listagem de Textos de Exposicao à Crise
+     *
+     * @return Response
+     */
+    public function textoExposicaoACrise()
+    {
+    	return response(TextoExposicaoACrise::get());
     }
 
     /**

--- a/app/Http/Controllers/TextoExposicaoACriseController.php
+++ b/app/Http/Controllers/TextoExposicaoACriseController.php
@@ -20,7 +20,6 @@ class TextoExposicaoACriseController extends AppBaseController
     public function __construct(TextoExposicaoACriseRepository $textoExposicaoACriseRepo)
     {
         $this->textoExposicaoACriseRepository = $textoExposicaoACriseRepo;
-        $this->middleware('auth');
     }
 
     /**

--- a/app/Http/Controllers/TextoPosicaoFinanceiraController.php
+++ b/app/Http/Controllers/TextoPosicaoFinanceiraController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\TextoPosicaoFinanceira;
 use App\DataTables\TextoPosicaoFinanceiraDataTable;
 use App\Http\Requests;
 use App\Http\Requests\CreateTextoPosicaoFinanceiraRequest;
@@ -19,6 +20,7 @@ class TextoPosicaoFinanceiraController extends AppBaseController
     public function __construct(TextoPosicaoFinanceiraRepository $textoPosicaoFinanceiraRepo)
     {
         $this->textoPosicaoFinanceiraRepository = $textoPosicaoFinanceiraRepo;
+        $this->middleware('auth');
     }
 
     /**
@@ -30,6 +32,16 @@ class TextoPosicaoFinanceiraController extends AppBaseController
     public function index(TextoPosicaoFinanceiraDataTable $textoPosicaoFinanceiraDataTable)
     {
         return $textoPosicaoFinanceiraDataTable->render('texto_posicao_financeiras.index');
+    }
+
+    /**
+     * Retorna Listagem de Textos de Posição Financeira
+     *
+     * @return Response
+     */
+    public function textoPosicaoFinanceira()
+    {
+    	return response(TextoPosicaoFinanceira::get());
     }
 
     /**

--- a/app/Http/Controllers/TextoPosicaoFinanceiraController.php
+++ b/app/Http/Controllers/TextoPosicaoFinanceiraController.php
@@ -20,7 +20,6 @@ class TextoPosicaoFinanceiraController extends AppBaseController
     public function __construct(TextoPosicaoFinanceiraRepository $textoPosicaoFinanceiraRepo)
     {
         $this->textoPosicaoFinanceiraRepository = $textoPosicaoFinanceiraRepo;
-        $this->middleware('auth');
     }
 
     /**

--- a/app/Http/Controllers/TextoPosicionamentoEstrategicoController.php
+++ b/app/Http/Controllers/TextoPosicionamentoEstrategicoController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\TextoPosicionamentoEstrategico;
 use App\DataTables\TextoPosicionamentoEstrategicoDataTable;
 use App\Http\Requests;
 use App\Http\Requests\CreateTextoPosicionamentoEstrategicoRequest;
@@ -19,6 +20,7 @@ class TextoPosicionamentoEstrategicoController extends AppBaseController
     public function __construct(TextoPosicionamentoEstrategicoRepository $textoPosicionamentoEstrategicoRepo)
     {
         $this->textoPosicionamentoEstrategicoRepository = $textoPosicionamentoEstrategicoRepo;
+        $this->middleware('auth');
     }
 
     /**
@@ -30,6 +32,16 @@ class TextoPosicionamentoEstrategicoController extends AppBaseController
     public function index(TextoPosicionamentoEstrategicoDataTable $textoPosicionamentoEstrategicoDataTable)
     {
         return $textoPosicionamentoEstrategicoDataTable->render('texto_posicionamento_estrategicos.index');
+    }
+
+    /**
+     * Retorna Listagem de Textos de Posicionamento Estratégico
+     *
+     * @return Response
+     */
+    public function textoPosicionamentoEstrategico()
+    {
+    	return response(TextoPosicionamentoEstrategico::get());
     }
 
     /**

--- a/app/Http/Controllers/TextoPosicionamentoEstrategicoController.php
+++ b/app/Http/Controllers/TextoPosicionamentoEstrategicoController.php
@@ -20,7 +20,6 @@ class TextoPosicionamentoEstrategicoController extends AppBaseController
     public function __construct(TextoPosicionamentoEstrategicoRepository $textoPosicionamentoEstrategicoRepo)
     {
         $this->textoPosicionamentoEstrategicoRepository = $textoPosicionamentoEstrategicoRepo;
-        $this->middleware('auth');
     }
 
     /**

--- a/app/Http/Controllers/TextosCuboController.php
+++ b/app/Http/Controllers/TextosCuboController.php
@@ -20,7 +20,6 @@ class TextosCuboController extends AppBaseController
     public function __construct(TextosCuboRepository $textosCuboRepo)
     {
         $this->textosCuboRepository = $textosCuboRepo;
-        $this->middleware('auth');
     }
 
     /**

--- a/app/Http/Controllers/TextosCuboController.php
+++ b/app/Http/Controllers/TextosCuboController.php
@@ -44,6 +44,34 @@ class TextosCuboController extends AppBaseController
     }
 
     /**
+     * Retorna Listagem de resposta do Cubo
+     *
+     * @param tipo_resposta onde 
+     * crise = reposta para exposição a crise,
+     * estrategico = reposta para posicionamento estrategico
+     * posicao = reposta para posição financeira
+     *
+     * @return Response
+     */
+    public function respostaCubo($tipo_resposta = 'crise')
+    {
+	$param_response = [
+		'crise'       => 'resposta_ec',
+		'estrategico' => 'resposta_pe',
+		'posicao'     => 'resposta_pf',
+	];
+
+	try {
+		$resposta = $param_response[$tipo_resposta];
+
+		return response(TextosCubo::get([$resposta]));
+		
+	} catch (\Throwable $e) {
+		return redirect()->route('resposta_cubo');
+	}
+    }
+
+    /**
      * Show the form for creating a new TextosCubo.
      *
      * @return Response

--- a/app/Http/Controllers/TextosCuboController.php
+++ b/app/Http/Controllers/TextosCuboController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\TextosCubo;
 use App\DataTables\TextosCuboDataTable;
 use App\Http\Requests;
 use App\Http\Requests\CreateTextosCuboRequest;
@@ -19,6 +20,7 @@ class TextosCuboController extends AppBaseController
     public function __construct(TextosCuboRepository $textosCuboRepo)
     {
         $this->textosCuboRepository = $textosCuboRepo;
+        $this->middleware('auth');
     }
 
     /**
@@ -30,6 +32,16 @@ class TextosCuboController extends AppBaseController
     public function index(TextosCuboDataTable $textosCuboDataTable)
     {
         return $textosCuboDataTable->render('textos_cubos.index');
+    }
+
+    /**
+     * Retorna Listagem de Textos do Cubo
+     *
+     * @return Response
+     */
+    public function textosCubo()
+    {
+    	return response(TextosCubo::get());
     }
 
     /**

--- a/app/Http/Controllers/TextosDetalhamentoIniciativaController.php
+++ b/app/Http/Controllers/TextosDetalhamentoIniciativaController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\TextosDetalhamentoIniciativa;
 use App\DataTables\TextosDetalhamentoIniciativaDataTable;
 use App\Http\Requests;
 use App\Http\Requests\CreateTextosDetalhamentoIniciativaRequest;
@@ -19,6 +20,7 @@ class TextosDetalhamentoIniciativaController extends AppBaseController
     public function __construct(TextosDetalhamentoIniciativaRepository $textosDetalhamentoIniciativaRepo)
     {
         $this->textosDetalhamentoIniciativaRepository = $textosDetalhamentoIniciativaRepo;
+        $this->middleware('auth');
     }
 
     /**
@@ -30,6 +32,16 @@ class TextosDetalhamentoIniciativaController extends AppBaseController
     public function index(TextosDetalhamentoIniciativaDataTable $textosDetalhamentoIniciativaDataTable)
     {
         return $textosDetalhamentoIniciativaDataTable->render('textos_detalhamento_iniciativas.index');
+    }
+
+    /**
+     * Retorna Listagem de Textos de Detalhamento de Iniciativa
+     *
+     * @return Response
+     */
+    public function textosDetalhamentoIniciativa()
+    {
+    	return response(TextosDetalhamentoIniciativa::get());
     }
 
     /**

--- a/app/Http/Controllers/TextosDetalhamentoIniciativaController.php
+++ b/app/Http/Controllers/TextosDetalhamentoIniciativaController.php
@@ -20,7 +20,6 @@ class TextosDetalhamentoIniciativaController extends AppBaseController
     public function __construct(TextosDetalhamentoIniciativaRepository $textosDetalhamentoIniciativaRepo)
     {
         $this->textosDetalhamentoIniciativaRepository = $textosDetalhamentoIniciativaRepo;
-        $this->middleware('auth');
     }
 
     /**

--- a/app/Http/Controllers/TextosIniciativaController.php
+++ b/app/Http/Controllers/TextosIniciativaController.php
@@ -20,7 +20,6 @@ class TextosIniciativaController extends AppBaseController
     public function __construct(TextosIniciativaRepository $textosIniciativaRepo)
     {
         $this->textosIniciativaRepository = $textosIniciativaRepo;
-        $this->middleware('auth');
     }
 
     /**

--- a/app/Http/Controllers/TextosIniciativaController.php
+++ b/app/Http/Controllers/TextosIniciativaController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\TextosIniciativa;
 use App\DataTables\TextosIniciativaDataTable;
 use App\Http\Requests;
 use App\Http\Requests\CreateTextosIniciativaRequest;
@@ -19,6 +20,7 @@ class TextosIniciativaController extends AppBaseController
     public function __construct(TextosIniciativaRepository $textosIniciativaRepo)
     {
         $this->textosIniciativaRepository = $textosIniciativaRepo;
+        $this->middleware('auth');
     }
 
     /**
@@ -30,6 +32,16 @@ class TextosIniciativaController extends AppBaseController
     public function index(TextosIniciativaDataTable $textosIniciativaDataTable)
     {
         return $textosIniciativaDataTable->render('textos_iniciativas.index');
+    }
+
+    /**
+     * Retorna Listagem de Textos de Iniciativa
+     *
+     * @return Response
+     */
+    public function textosIniciativa()
+    {
+    	return response(TextosIniciativa::get());
     }
 
     /**

--- a/app/Http/Controllers/TextosIniciativaController.php
+++ b/app/Http/Controllers/TextosIniciativaController.php
@@ -34,6 +34,16 @@ class TextosIniciativaController extends AppBaseController
     }
 
     /**
+     * Endpoint para caminhos de Anexos
+     *
+     * @return Response
+     */
+    public function anexos()
+    {
+    	return response(TextosIniciativa::get(['path_pdf']));
+    }
+
+    /**
      * Retorna Listagem de Textos de Iniciativa
      *
      * @return Response

--- a/database/seeds/AdminSeeder.php
+++ b/database/seeds/AdminSeeder.php
@@ -15,7 +15,7 @@ class AdminSeeder extends Seeder
 	    User::create([
 		    'name' => 'Admin - Tesseract',
 		    'email' => 'admin@grupotesseract.com.br',
-		    'password' => 'admintesseract',
+		    'password' => bcrypt('admintesseract'),
 	    ]);
     }
 }

--- a/database/seeds/AdminSeeder.php
+++ b/database/seeds/AdminSeeder.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Seeder;
+use App\Models\User;
+
+class AdminSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+	    User::create([
+		    'name' => 'Admin - Tesseract',
+		    'email' => 'admin@grupotesseract.com.br',
+		    'password' => 'admintesseract',
+	    ]);
+    }
+}

--- a/resources/views/textos_detalhamento_iniciativas/fields.blade.php
+++ b/resources/views/textos_detalhamento_iniciativas/fields.blade.php
@@ -4,6 +4,12 @@
     {!! Form::textarea('descritivo', null, ['class' => 'form-control']) !!}
 </div>
 
+<!-- Iniciativa Id Field -->
+<div class="form-group col-sm-6">
+    {!! Form::label('texto_iniciativa_id', 'Iniciativa Id:') !!}
+    {!! Form::text('texto_iniciativa_id', null, ['class' => 'form-control']) !!}
+</div>
+
 <!-- Submit Field -->
 <div class="form-group col-sm-12">
     {!! Form::submit('Salvar', ['class' => 'btn btn-primary']) !!}

--- a/routes/web.php
+++ b/routes/web.php
@@ -34,6 +34,8 @@ Route::get('api/texto_posicao_financeira', 'TextoPosicaoFinanceiraController@tex
 
 Route::get('api/texto_cubo', 'TextosCuboController@textosCubo');
 
+Route::get('api/resposta_cubo/{tipo_resposta?}', 'TextosCuboController@respostaCubo')->name('resposta_cubo');
+
 Route::get('api/texto_iniciativa', 'TextosIniciativaController@textosIniciativa');
 
 Route::get('api/anexos', 'TextosIniciativaController@anexos');

--- a/routes/web.php
+++ b/routes/web.php
@@ -36,6 +36,8 @@ Route::get('api/texto_cubo', 'TextosCuboController@textosCubo');
 
 Route::get('api/texto_iniciativa', 'TextosIniciativaController@textosIniciativa');
 
+Route::get('api/anexos', 'TextosIniciativaController@anexos');
+
 Route::get('api/texto_detalhamento_iniciativa', 'TextosDetalhamentoIniciativaController@textosDetalhamentoIniciativa');
 
 Auth::routes();

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,6 +22,22 @@ Route::get('/home', 'HomeController@index');
 
 Route::resource('users', 'UserController');
 
+// Rotas para API
+
+Route::get('api/texto_entrada', 'TextoEntradaController@textoEntrada');
+
+Route::get('api/texto_exposicao_a_crise', 'TextoExposicaoACriseController@textoExposicaoACrise');
+
+Route::get('api/texto_posicionamento_estrategico', 'TextoPosicionamentoEstrategicoController@textoPosicionamentoEstrategico');
+
+Route::get('api/texto_posicao_financeira', 'TextoPosicaoFinanceiraController@textoPosicaoFinanceira');
+
+Route::get('api/texto_cubo', 'TextosCuboController@textosCubo');
+
+Route::get('api/texto_iniciativa', 'TextosIniciativaController@textosIniciativa');
+
+Route::get('api/texto_detalhamento_iniciativa', 'TextosDetalhamentoIniciativaController@textosDetalhamentoIniciativa');
+
 Auth::routes();
 
 
@@ -38,3 +54,4 @@ Route::resource('textosCubos', 'TextosCuboController');
 Route::resource('textosIniciativas', 'TextosIniciativaController');
 
 Route::resource('textosDetalhamentoIniciativas', 'TextosDetalhamentoIniciativaController');
+


### PR DESCRIPTION
Contém as alterações de https://github.com/grupotesseract/fabiao/pull/11 e mais algumas para contemplar os tickets https://www.pivotaltracker.com/story/show/160158842 e https://www.pivotaltracker.com/story/show/160158850

Pra facilitar, vou colar aqui também além do pivotal informações sobre o endpoint do cubo e seu parâmetro, o de anexos é só dar GET seco, n tem segredo:

- Rota pra dar GET: **'api/resposta_cubo/{tipo_resposta?}'** ex: **api/resposta_cubo/crise**
- Tipos de resposta: 'crise' p/ resposta de exposição à crise, 'estrategico' p/ resposta de posicionamento estratégico e 'posicao' p/ resposta de posição financeira
- Qualquer tipo nada a ver inserido no parâmetro ou a ausência dele vai redirecionar para a resposta de exposição à crise p/ evitar alguns erros nesses casos.