### PR TITLE
Unifica informações para resposta do cubo

### DIFF
--- a/app/DataTables/TextosDetalhamentoIniciativaDataTable.php
+++ b/app/DataTables/TextosDetalhamentoIniciativaDataTable.php
@@ -65,7 +65,6 @@ class TextosDetalhamentoIniciativaDataTable extends DataTable
     {
         return [
             'descritivo',
-            'texto_iniciativa_id'
         ];
     }
 

--- a/app/Http/Controllers/TextosCuboController.php
+++ b/app/Http/Controllers/TextosCuboController.php
@@ -77,7 +77,7 @@ class TextosCuboController extends AppBaseController
                 ['resposta_pf', 'ilike',  $json['resposta_pf']],
             ];
 
-            $resposta = TextosCubo::where($respostas_condition)->first();
+            $resposta = TextosCubo::where($respostas_condition)->with('textosIniciativa.subitems')->first();
 
             return response($resposta);
 

--- a/app/Http/Controllers/TextosDetalhamentoIniciativaController.php
+++ b/app/Http/Controllers/TextosDetalhamentoIniciativaController.php
@@ -34,16 +34,6 @@ class TextosDetalhamentoIniciativaController extends AppBaseController
     }
 
     /**
-     * Retorna Listagem de Textos de Detalhamento de Iniciativa
-     *
-     * @return Response
-     */
-    public function textosDetalhamentoIniciativa()
-    {
-    	return response(TextosDetalhamentoIniciativa::get());
-    }
-
-    /**
      * Show the form for creating a new TextosDetalhamentoIniciativa.
      *
      * @return Response

--- a/app/Http/Controllers/TextosIniciativaController.php
+++ b/app/Http/Controllers/TextosIniciativaController.php
@@ -34,16 +34,6 @@ class TextosIniciativaController extends AppBaseController
     }
 
     /**
-     * Retorna Listagem de Textos de Iniciativa
-     *
-     * @return Response
-     */
-    public function textosIniciativa($id_resposta_cubo)
-    {
-    	return response(TextosIniciativa::where('textos_cubos_id', $id_resposta_cubo)->with('filhos')->get());
-    }
-
-    /**
      * Show the form for creating a new TextosIniciativa.
      *
      * @return Response

--- a/app/Models/TextosCubo.php
+++ b/app/Models/TextosCubo.php
@@ -23,9 +23,9 @@ class TextosCubo extends Model
 
     public $table = 'textos_cubos';
 
+    protected $hidden = ['created_at', 'deleted_at', 'updated_at'];
 
     protected $dates = ['deleted_at'];
-
 
     public $fillable = [
         'descritivo',
@@ -71,7 +71,7 @@ class TextosCubo extends Model
      */
     public function textosIniciativa()
     {
-        return $this->hasMany('App\Models\TextosIniciativa', 'id');
+        return $this->hasMany('App\Models\TextosIniciativa', 'textos_cubos_id');
     }
 
 

--- a/app/Models/TextosDetalhamentoIniciativa.php
+++ b/app/Models/TextosDetalhamentoIniciativa.php
@@ -19,6 +19,7 @@ class TextosDetalhamentoIniciativa extends Model
 
     public $table = 'textos_detalhamento_iniciativas';
     
+    protected $hidden = ['created_at', 'deleted_at', 'updated_at'];
 
     protected $dates = ['deleted_at'];
 
@@ -45,14 +46,5 @@ class TextosDetalhamentoIniciativa extends Model
      */
     public static $rules = [
         'descritivo' => 'required',
-        'texto_iniciativa_id' => 'required'
     ];
-
-    public function pai()
-    {
-        return $this->belongsTo('App\Models\TextosIniciativa', 'texto_iniciativa_id');
-    }
-    
-
-    
 }

--- a/app/Models/TextosIniciativa.php
+++ b/app/Models/TextosIniciativa.php
@@ -24,6 +24,8 @@ class TextosIniciativa extends Model
 
     protected $dates = ['deleted_at'];
 
+    protected $hidden = ['created_at', 'deleted_at', 'updated_at'];
+
     public $fillable = [
         'descritivo',
         'descritivo_pai',
@@ -55,17 +57,16 @@ class TextosIniciativa extends Model
         'descritivo_pai' => 'required',
         'numero' => 'required',
         'prioridade' => 'required',
-        'textos_cubos_id' => 'required',
     ];
 
     /**
-     * relacionamento p/ retornar cubo
+     * relacionamento p/ retornar filhos
      *
      * @return void
      */
-    public function filhos()
+    public function subitems()
     {
-    	return $this->hasMany('App\Models\TextosDetalhamentoIniciativa', 'id');
+    	return $this->hasMany('App\Models\TextosDetalhamentoIniciativa', 'texto_iniciativa_id');
     }
     
 

--- a/resources/views/textos_cubos/show_fields.blade.php
+++ b/resources/views/textos_cubos/show_fields.blade.php
@@ -1,9 +1,3 @@
-<!-- Id Field -->
-<div class="form-group">
-    {!! Form::label('id', 'Id:') !!}
-    <p>{!! $textosCubo->id !!}</p>
-</div>
-
 <!-- Descritivo Field -->
 <div class="form-group">
     {!! Form::label('descritivo', 'Descritivo:') !!}
@@ -39,16 +33,3 @@
     {!! Form::label('valor_compra', 'Valor Compra:') !!}
     <p>{!! $textosCubo->valor_compra !!}</p>
 </div>
-
-<!-- Created At Field -->
-<div class="form-group">
-    {!! Form::label('created_at', 'Created At:') !!}
-    <p>{!! $textosCubo->created_at !!}</p>
-</div>
-
-<!-- Updated At Field -->
-<div class="form-group">
-    {!! Form::label('updated_at', 'Updated At:') !!}
-    <p>{!! $textosCubo->updated_at !!}</p>
-</div>
-

--- a/resources/views/textos_detalhamento_iniciativas/fields.blade.php
+++ b/resources/views/textos_detalhamento_iniciativas/fields.blade.php
@@ -4,12 +4,6 @@
     {!! Form::textarea('descritivo', null, ['class' => 'form-control']) !!}
 </div>
 
-<!-- Iniciativa Id Field -->
-<div class="form-group col-sm-6">
-    {!! Form::label('texto_iniciativa_id', 'Iniciativa Id:') !!}
-    {!! Form::text('texto_iniciativa_id', null, ['class' => 'form-control']) !!}
-</div>
-
 <!-- Submit Field -->
 <div class="form-group col-sm-12">
     {!! Form::submit('Salvar', ['class' => 'btn btn-primary']) !!}

--- a/resources/views/textos_detalhamento_iniciativas/show_fields.blade.php
+++ b/resources/views/textos_detalhamento_iniciativas/show_fields.blade.php
@@ -1,30 +1,5 @@
-<!-- Id Field -->
-<div class="form-group">
-    {!! Form::label('id', 'Id:') !!}
-    <p>{!! $textosDetalhamentoIniciativa->id !!}</p>
-</div>
-
 <!-- Descritivo Field -->
 <div class="form-group">
     {!! Form::label('descritivo', 'Descritivo:') !!}
     <p>{!! $textosDetalhamentoIniciativa->descritivo !!}</p>
 </div>
-
-<!-- Texto Iniciativa Id Field -->
-<div class="form-group">
-    {!! Form::label('texto_iniciativa_id', 'Texto Iniciativa Id:') !!}
-    <p>{!! $textosDetalhamentoIniciativa->texto_iniciativa_id !!}</p>
-</div>
-
-<!-- Created At Field -->
-<div class="form-group">
-    {!! Form::label('created_at', 'Created At:') !!}
-    <p>{!! $textosDetalhamentoIniciativa->created_at !!}</p>
-</div>
-
-<!-- Updated At Field -->
-<div class="form-group">
-    {!! Form::label('updated_at', 'Updated At:') !!}
-    <p>{!! $textosDetalhamentoIniciativa->updated_at !!}</p>
-</div>
-

--- a/resources/views/textos_iniciativas/fields.blade.php
+++ b/resources/views/textos_iniciativas/fields.blade.php
@@ -22,12 +22,6 @@
     {!! Form::number('prioridade', null, ['class' => 'form-control']) !!}
 </div>
 
-<!-- Textos Cubos Id Field -->
-<div class="form-group col-sm-6">
-    {!! Form::label('textos_cubos_id', 'Textos Cubos Id:') !!}
-    {!! Form::text('textos_cubos_id', null, ['class' => 'form-control']) !!}
-</div>
-
 <!-- Submit Field -->
 <div class="form-group col-sm-12">
     {!! Form::submit('Salvar', ['class' => 'btn btn-primary']) !!}

--- a/resources/views/textos_iniciativas/show_fields.blade.php
+++ b/resources/views/textos_iniciativas/show_fields.blade.php
@@ -1,9 +1,3 @@
-<!-- Id Field -->
-<div class="form-group">
-    {!! Form::label('id', 'Id:') !!}
-    <p>{!! $textosIniciativa->id !!}</p>
-</div>
-
 <!-- Descritivo Field -->
 <div class="form-group">
     {!! Form::label('descritivo', 'Descritivo:') !!}
@@ -27,16 +21,3 @@
     {!! Form::label('prioridade', 'Prioridade:') !!}
     <p>{!! $textosIniciativa->prioridade !!}</p>
 </div>
-
-<!-- Created At Field -->
-<div class="form-group">
-    {!! Form::label('created_at', 'Created At:') !!}
-    <p>{!! $textosIniciativa->created_at !!}</p>
-</div>
-
-<!-- Updated At Field -->
-<div class="form-group">
-    {!! Form::label('updated_at', 'Updated At:') !!}
-    <p>{!! $textosIniciativa->updated_at !!}</p>
-</div>
-

--- a/routes/web.php
+++ b/routes/web.php
@@ -36,7 +36,5 @@ Route::group(['prefix' => 'admin'], function () {
 Route::get('api/texto_entrada', 'TextoEntradaController@textoEntrada');
 Route::get('api/perguntas', 'PerguntasController@perguntas');
 Route::get('api/texto_cubo', 'TextosCuboController@textosCubo')->name('texto_cubo');
-Route::get('api/texto_iniciativa/{id_resposta_cubo}', 'TextosIniciativaController@textosIniciativa');
 Route::get('api/anexos/{id}', 'TextosCuboController@anexos');
-Route::get('api/texto_detalhamento_iniciativa', 'TextosDetalhamentoIniciativaController@textosDetalhamentoIniciativa');
 Route::post('api/resposta_cubo/', 'TextosCuboController@respostaCubo')->name('resposta_cubo');


### PR DESCRIPTION
## Alterações:
- Junta os dados pertinentes ao que o endpoint de resposta do cubo necessita (segue em anexo um exemplo de json a ser enviado pro endpoint e da sua respectiva resposta)

[exemplo.zip](https://github.com/grupotesseract/fabiao/files/2434651/exemplo.zip)

- Remoção de rotas que se tornaram obsoletas com isso: 'api/texto_iniciativa' e 'api/texto_detalhamento_iniciativa'

- Remoção de colunas que mostravam ID/FKs de texto_iniciativa e textos_detalhamento_iniciativa

